### PR TITLE
Add Electron interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ python list_apps.py
 
 A window will appear listing all discovered applications. On unsupported
 platforms the list may be empty.
+
+
+You can also launch the Electron interface. From the `electron-app` directory install dependencies and run:
+
+```bash
+npm install
+npm start
+```

--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Installed Applications</title>
+</head>
+<body>
+  <h1>Installed Applications</h1>
+  <ul id="apps"></ul>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 600,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "electron-app",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^29.0.0"
+  }
+}

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -1,0 +1,25 @@
+const { execFile } = require('child_process');
+const path = require('path');
+
+function loadApps() {
+  const script = path.join(__dirname, '..', 'list_apps.py');
+  execFile('python', [script, '--json'], (error, stdout, stderr) => {
+    if (error) {
+      document.getElementById('apps').textContent = 'Error: ' + error.message;
+      return;
+    }
+    try {
+      const apps = JSON.parse(stdout);
+      const ul = document.getElementById('apps');
+      apps.forEach(app => {
+        const li = document.createElement('li');
+        li.textContent = app;
+        ul.appendChild(li);
+      });
+    } catch (e) {
+      document.getElementById('apps').textContent = 'Failed to parse output.';
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', loadApps);

--- a/list_apps.py
+++ b/list_apps.py
@@ -1,5 +1,7 @@
 import os
 import platform
+import sys
+import json
 import tkinter as tk
 from tkinter import ttk
 
@@ -64,6 +66,10 @@ def get_installed_apps():
 
 def main():
     apps = get_installed_apps()
+    if "--json" in sys.argv:
+        print(json.dumps(apps))
+        return
+
 
     root = tk.Tk()
     root.title('Installed Applications')


### PR DESCRIPTION
## Summary
- support JSON output in Python script
- document new Electron interface
- create Electron app that runs the Python script

## Testing
- `python list_apps.py --json` *(fails: `ModuleNotFoundError: No module named 'tkinter'`)*
- `node --version` *(fails: `node: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68456a6b4794832ab76e17e08c9f1e04